### PR TITLE
change move command to also move any dotfiles in unzipped directory, …

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -71,7 +71,7 @@ jobs:
       # You may not need this step depending on the contents of the zip
       - name: Move
         if: ${{ steps.previous_version.outputs.tag != steps.new_version.outputs.new_version }}
-        run: sudo mv ${{ env.PACKAGE_SLUG }}/* .
+        run: sudo mv ${{ env.PACKAGE_SLUG }}/{,.[^.]}* .
       
       - name: rm
         if: ${{ steps.previous_version.outputs.tag != steps.new_version.outputs.new_version }}


### PR DESCRIPTION
…else rm will fail

Found this out when an unzipped `package.zip` created a folder with files such as:

```bash
plugin-directory/.idea/php.xml
plugin-directory/.gitignore
plugin-directory/.vscode/launch.json
```

The action will then fail at the `rm` step with a permission denied.

Alternative is to change `rm` command to `sudo rm` but I suppose there might be plugins that have a reason to have dotfiles within their directory, so should be moved and committed...